### PR TITLE
Fixes the branch of ci to be master instead of main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [master]
 jobs:
   test:
     name: test ${{ matrix.py }}


### PR DESCRIPTION
At some point we should rename main -> master but until then, we should run CI on master