### PR TITLE
Add support for serializing/deserializing 

### DIFF
--- a/docs/Serialization.md
+++ b/docs/Serialization.md
@@ -1,0 +1,9 @@
+# Serialization
+
+Expression objects can be turned into JSON ready values with the `expr_to_json_value`
+function, and vice versa with the `json_value_to_expr` function. Leaf nodes will be serialized as binary strings with pickling.
+
+```python
+
+
+```

--- a/metadsl/normalized.py
+++ b/metadsl/normalized.py
@@ -2,16 +2,17 @@
 Normalized expressions, for deduping and single replacements.
 """
 from __future__ import annotations
-import dataclasses
-import typing
-import itertools
+
 import collections
+import dataclasses
 import functools
-import IPython.core.display
+import itertools
+import typing
+
 import igraph
+import IPython.core.display
 
 from .expressions import *
-
 
 __all__ = [
     "ExpressionReference",
@@ -37,11 +38,11 @@ class Graph(igraph.Graph):
     * `index`: int or string
     """
 
-    def __init__(self, expr: object):
+    def __init__(self, expr: object=None):
         super().__init__(directed=True)
-
-        self.fully_add_expression(expr, None)
-        self.assert_integrity()
+        if expr is not None:
+            self.fully_add_expression(expr, None)
+            self.assert_integrity()
 
     def _repr_svg_(self):
         return self.plot_custom()._repr_svg_()

--- a/metadsl_visualize/typez.py
+++ b/metadsl_visualize/typez.py
@@ -3,9 +3,12 @@ Integeration with typez, to translate a "Rule" into a something that takes retur
 typez object we can use to display as we go.
 """
 
+import base64
 import dataclasses
 import functools
+import importlib
 import inspect
+import pickle
 import types
 import typing
 import warnings
@@ -13,10 +16,15 @@ import warnings
 import black
 import metadsl
 import typing_inspect
-from typez import *
+from metadsl.expressions import Expression
+from metadsl.normalized import Graph, Hash
+from metadsl.typing_tools import BoundInfer, Infer
 from metadsl_rewrite import *
 
-__all__ = ["ExpressionDisplay", "SHOW_MODULE"]
+from typez import *
+from typez import FunctionValue
+
+__all__ = ["ExpressionDisplay", "SHOW_MODULE", "expr_to_json_value", "json_value_to_expr"]
 
 
 @functools.singledispatch
@@ -39,12 +47,7 @@ class ExpressionDisplay:
     )
 
     def __post_init__(self):
-        ref = self.ref
-        nodes = convert_to_nodes(ref)
-        initial_node_id = str(ref.hash)
-        self.typez_display.typez = Typez(
-            states=States(initial=initial_node_id), nodes=nodes
-        )
+        self.typez_display.typez = expression_ref_to_typez(self.ref)
 
     def update(self, result: Result):
         new_nodes = convert_to_nodes(self.ref)
@@ -81,7 +84,18 @@ class ExpressionDisplay:
 black_file_mode = black.FileMode(line_length=40)
 
 
-def convert_to_nodes(ref: metadsl.ExpressionReference) -> Nodes:
+def expression_ref_to_typez(
+    ref: metadsl.ExpressionReference, save_pickle=False
+) -> Typez:
+    """
+    Converts an expression reference to a typez.
+    """
+    nodes = convert_to_nodes(ref, save_pickle=save_pickle)
+    initial_node_id = str(ref.hash)
+    return Typez(states=States(initial=initial_node_id), nodes=nodes)
+
+
+def convert_to_nodes(ref: metadsl.ExpressionReference, save_pickle=False) -> Nodes:
     """
     Converts an expression into a node mapping.
     """
@@ -102,6 +116,7 @@ def convert_to_nodes(ref: metadsl.ExpressionReference) -> Nodes:
                     f"{func_str}\n{value._type_str}" if SHOW_TYPES else func_str,
                     mode=black_file_mode,
                 ),
+                function_value=expression_to_function_value(value),
                 args=[str(a) for a in children.args] or None,
                 kwargs={k: str(v) for k, v in children.kwargs.items()} or None,
             )
@@ -110,9 +125,74 @@ def convert_to_nodes(ref: metadsl.ExpressionReference) -> Nodes:
                 id=str(ref.hash),
                 type=function_or_type_repr(type(value)),
                 repr=metadsl_str(value),
+                python_pickle=pickle_string(value) if save_pickle else None,
             )
         nodes.append(node)
     return nodes
+
+
+def expression_to_function_value(expr: metadsl.Expression) -> FunctionValue:
+    """
+    Converts an expression to a FunctionValue.
+    """
+    fn = expr.function
+    assert isinstance(fn, (BoundInfer, Infer))
+    return FunctionValue(
+        module=fn.__module__,
+        name=fn.fn.__name__,
+        class_=fn.owner.__name__ if isinstance(fn, BoundInfer) else None,
+    )
+
+def function_value_to_fn(fv: FunctionValue) -> types.FunctionType:
+    v: typing.Any = importlib.import_module(fv.module)
+    if fv.class_ is not None:
+        v = getattr(v, fv.class_)
+    return getattr(v, fv.name)
+
+
+def pickle_string(value: object) -> str:
+    """
+    Returns the object pickled with Python protocol 5 pickle, encoded as a string
+    """
+    return base64.b64encode(pickle.dumps(value, protocol=5)).decode("ascii")
+
+
+def load_pickle(v: str) -> object:
+    return pickle.loads(base64.b64decode(v))
+
+
+def expr_to_json_value(expr: metadsl.Expression) -> dict:
+    """
+    Converts an expression to a JSON value, suitable to be serialized to a string.
+    """
+    expr_ref = metadsl.ExpressionReference.from_expression(expr)
+    return expression_ref_to_typez(expr_ref, save_pickle=True).asdict()
+
+
+def json_value_to_expr(value: dict) -> metadsl.Expression:
+    """
+    Converts a JSON value to an expression.
+    """
+    typez = Typez.from_dict(value)
+    graph = Graph()
+    assert typez.nodes
+    for node in typez.nodes:
+        if isinstance(node, PrimitiveNode):
+            assert node.python_pickle
+            expression = load_pickle(node.python_pickle)
+        else:
+            expression = Expression(
+                # TODO: replace typevars as well
+                function=function_value_to_fn(node.function_value),
+                args=[graph.lookup(Hash(a))["expression"] for a in node.args or []],
+                kwargs={
+                    k: graph.lookup(Hash(v))["expression"]
+                    for k, v in (node.kwargs or {}).items()
+                },
+            )
+        graph.add_vertex(expression=expression, name=node.id)
+    assert typez.states
+    return graph.lookup(Hash(typez.states.initial))['expression']
 
 
 def typevars_to_typeparams(

--- a/typez/src/schema.ts
+++ b/typez/src/schema.ts
@@ -111,9 +111,18 @@ export type CallNode = {
 };
 
 /**
+ * The value of the function, either a top level one or a class method
+ */
+export type FunctionValue = {
+  module: string;
+  name: string;
+  class_?: string;
+}
+
+/**
  * A primitive node that represents some type in  the host language
  */
-type PrimitiveNode = { id: string; type: string; repr: string };
+type PrimitiveNode = { id: string; type: string; repr: string; python_pickle?: string };
 
 /**
  * A type that is passed into a function to set one of its  type


### PR DESCRIPTION
This adds initial support for serializing/deserializing expression objects to JSON. This re-uses the existing JSON format we use for visualization, and adds the ability to save the pickled contents of leaf nodes as data.