### PR TITLE
Add support for automatically wrapping all methods as expression

### DIFF
--- a/docs/Principles.md
+++ b/docs/Principles.md
@@ -1,0 +1,15 @@
+# Principles
+
+
+## Works with MyPy out of the box
+
+One of the core constraints of this package is that it is meant to work with Mypy, or
+other type checkers, out of the box, without any custom plugins. This greatly constrains
+our design space, which is intentional. It means that any functionality should be typed
+in a way that is compatible with Mypy, without relying on any metaprogramming to define
+the type signatures of objects.
+
+The reason for this constraint is to keep us "pythonic", to make any code we write
+look closer to regular Python and keep us from veering too much off into our own
+custom language. In this way, at least looking at the expression at the type level,
+we support a subset of Python semantics.

--- a/docs/rfcs/001-datatype-rules.md
+++ b/docs/rfcs/001-datatype-rules.md
@@ -1,0 +1,132 @@
+# RFC 0001 Datatype Rules
+
+## Motivation
+Currently in `metadsl` it is very cumbersome to define a datatype. A datatype is simply
+a type that holds a collection of other types. For example, here is how we would define
+a non generic pair of integers:
+
+```python
+class Pair(Expression):
+    @expression
+    @classmethod
+    def create(cls, a: int, b: int) -> Pair:
+        ...
+
+    @expression
+    @property
+    def a(self) -> int:
+        ...
+
+    @expression
+    @property
+    def b(self) -> int:
+        ...
+
+    @expression
+    def set_a(self, a: int) -> Pair:
+        ...
+
+    @expression
+    def set_b(self, b: int) -> Pair:
+        ...
+
+@register
+@rule
+def pair_datatype_rule(a: int, b: int, a2: int, b2: int):
+    yield Pair.create(a, b).a, a
+    yield Pair.create(a, b).b, b
+    yield Pair.create(a, b).set_a(a2), Pair.create(a2, b)
+    yield Pair.create(a, b).set_b(b2), Pair.create(a, b2)
+```
+
+This not only is error prone, but it is also very verbose. These datatypes are used
+often for things like holding state in an interpreter. The equivalent in pure Python
+is the `@dataclass` decorator.
+
+## Proposal
+
+We propse adding two features to make this more succinct:
+
+1. A `datatype_rule` function which will generate the rule for you based on inspecting
+   the class.
+2. Allow decorating all methods in a class automaticall in `@expression` by providing
+   a `@wrap_methods` decorator.
+
+With these two additions, the above example becomes:
+
+```python
+class Pair(Expression, wrap_methods=True):
+    @classmethod
+    def create(cls, a: int, b: int) -> Pair:
+        ...
+
+    @property
+    def a(self) -> int:
+        ...
+
+    @property
+    def b(self) -> int:
+        ...
+
+    def set_a(self, a: int) -> Pair:
+        ...
+
+    def set_b(self, b: int) -> Pair:
+        ...
+
+register(datatype_rule(Pair))
+```
+
+This is close to the minimal amount of code neccesary, to provide the proper method
+definitions statically for MyPy to reason about. For example, we could autogenerate
+these methods at runtime, but then statically a type checker would not be able to analyze
+this code.
+
+## Alternatives
+
+### Support `@dataclass` directly
+
+One obvious alternative is to support the `@dataclass` decorator directly. This would
+end up with code something like this:
+
+```python
+@expression
+@dataclass(frozen=True)
+class Pair:
+    a: int
+    b: int
+
+    def set_a(self, a: int) -> Pair:
+        ...
+
+    def set_b(self, b: int) -> Pair:
+        ...
+
+register(datatype_rule(Pair))
+```
+
+We would still need the functional setters, since we do not support mutations currently
+(`p.a = 10` would not work).
+
+We would also need to support the `__init__` method, which is not supported, we
+use that for creating the actual expressions.
+
+We would also need to turn the attributes into properties, so that we have  a method
+to refer to on the class object...
+
+
+Overall it also conflicts with our use of dataclasses as the actual expressions themselves.
+
+If we were to go down this route, we might want to change some assumptions about our
+base implementation. Instead actually having expression be instances of the type
+itself, we could have them all be instances of `Expression` and have a seperate
+`type` attribute, where we store our representation of the type.
+
+This would in turn open up the library to support other types besides those supported here
+in a more robust way... By in some sense proxying by default. It would mean we would
+be asked to suport more of Python's type system (unions, inheritence..) but we wouldn't
+have to do it all at once.
+
+Then we have a differnce between a wrapped object and an unwrapped one. 
+
+Anyways, the point being this too intensive to do right now. Let's postpone that.

--- a/metadsl/expressions.py
+++ b/metadsl/expressions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import itertools
+import types
 import typing
 
 import typing_inspect
@@ -101,7 +102,19 @@ class Expression(GenericCheck):
             and self.args == value.args
             and self.kwargs == value.kwargs
         )
-
+    
+    @classmethod
+    def __init_subclass__(cls, /, wrap_methods=False, **kwargs) -> None:
+        """
+        If `wrap_methods` is passed in a subclass, wrap all methods in an `expresion` decorator.
+        """
+        super().__init_subclass__(**kwargs)
+        if not wrap_methods:
+            return
+        for k, v in cls.__dict__.items():
+            if isinstance(v, (types.FunctionType, property, classmethod)):
+                # Need to use this setattr, instead of `setattr` so we can set the descriptor
+                type(cls).__setattr__(cls, k, expression(typing.cast(typing.Callable, v)))
 
 def clone_expression(expr: T) -> T:
     if isinstance(expr, Expression):

--- a/metadsl/expressions_test.py
+++ b/metadsl/expressions_test.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import typing
-import typing_inspect
+
 import pytest
+import typing_inspect
 
 from .expressions import *
 
@@ -139,3 +140,22 @@ U = typing.TypeVar("U")
 def test_clone_expression_generic():
     assert clone_expression(Generic[T].create()) == Generic[T].create()
     assert clone_expression(Generic[U].create()) == Generic[U].create()
+
+
+class A(Expression, wrap_methods=True):
+    @classmethod
+    def create(cls) -> A:
+        ...
+
+    def method(self) -> A:
+        ...
+
+    @property
+    def prop(self) -> A:
+        ...
+    
+
+def test_wrap_method() -> None:
+    assert A.create() == A(A.create, [], {})
+    assert A.create().method() == A(A.method, [A(A.create, [], {})], {})
+    assert A.create().prop == A(A.prop, [A(A.create, [], {})], {})

--- a/metadsl_core/boolean.py
+++ b/metadsl_core/boolean.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import typing
 
 from metadsl import *
-
 from metadsl_rewrite import *
 
 from .abstraction import *
@@ -17,31 +16,24 @@ T = typing.TypeVar("T")
 U = typing.TypeVar("U")
 
 
-class Boolean(Expression):
-    # TODO: Remove this
-    @expression
+class Boolean(Expression, wrap_methods=True):
     @classmethod
     def create(cls, b: bool) -> Boolean:
         ...
 
-    @expression
     def if_(self, true: T, false: T) -> T:
         ...
 
-    @expression
     def and_(self, other: Boolean) -> Boolean:
         ...
 
-    @expression
     def or_(self, other: Boolean) -> Boolean:
         ...
 
-    @expression
     @classmethod
     def true(cls) -> Boolean:
         return Boolean.create(True)
 
-    @expression
     @classmethod
     def false(cls) -> Boolean:
         return Boolean.create(False)

--- a/metadsl_core/conversion.py
+++ b/metadsl_core/conversion.py
@@ -21,8 +21,8 @@ V = typing.TypeVar("V")
 X = typing.TypeVar("X")
 
 
-class Converter(Expression, typing.Generic[T]):
-    @expression
+class Converter(Expression, typing.Generic[T], wrap_methods=True):
+
     @classmethod
     def convert(cls, value: object) -> Maybe[T]:
         """

--- a/metadsl_core/either.py
+++ b/metadsl_core/either.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
+
 import typing
 
 from metadsl import *
 from metadsl_rewrite import *
+
+from .abstraction import *
 from .conversion import *
 from .maybe import *
-from .abstraction import *
 from .strategies import *
 
 __all__ = ["Either"]
@@ -15,18 +17,15 @@ U = typing.TypeVar("U")
 V = typing.TypeVar("V")
 
 
-class Either(Expression, typing.Generic[T, U]):
-    @expression
+class Either(Expression, typing.Generic[T, U], wrap_methods=True):
     @classmethod
     def left(cls, value: T) -> Either[T, U]:
         ...
 
-    @expression
     @classmethod
     def right(cls, value: U) -> Either[T, U]:
         ...
 
-    @expression
     def match(self, left: Abstraction[T, V], right: Abstraction[U, V]) -> V:
         ...
 

--- a/metadsl_core/function.py
+++ b/metadsl_core/function.py
@@ -8,15 +8,15 @@ function.
 """
 from __future__ import annotations
 
+import typing
 
 from metadsl import *
 from metadsl_rewrite import *
 
-from .strategies import *
 from .abstraction import *
 from .conversion import *
 from .maybe import *
-import typing
+from .strategies import *
 
 __all__ = ["FunctionZero", "FunctionOne", "FunctionTwo", "FunctionThree"]
 
@@ -27,49 +27,42 @@ V = typing.TypeVar("V")
 X = typing.TypeVar("X")
 
 
-class FunctionZero(Expression, typing.Generic[T]):
+class FunctionZero(Expression, typing.Generic[T], wrap_methods=True):
     """
     Function with zero args.
     """
 
-    @expression
     @classmethod
     def from_fn(cls, fn: typing.Callable[[], T]) -> FunctionZero[T]:
         return cls.create(fn.__name__, fn())
 
-    @expression
     def __call__(self) -> T:
         ...
 
-    @expression
     @classmethod
     def create(cls, name: str, val: T) -> FunctionZero[T]:
         ...
 
     @property  # type: ignore
-    @expression
     def value(self) -> T:
         ...
 
-    @expression  # type: ignore
     @property
     def name(self) -> str:
         ...
 
 
-class FunctionOne(Expression, typing.Generic[T, U]):
+class FunctionOne(Expression, typing.Generic[T, U], wrap_methods=True):
     """
     Function with one arg.
     """
 
-    @expression
     @classmethod
     def from_fn(
         cls, fn: typing.Callable[[T], U], name=Maybe[str].nothing()
     ) -> FunctionOne[T, U]:
         return cls.create(name.default(fn.__name__), Abstraction.from_fn(fn))
 
-    @expression
     @classmethod
     def from_fn_recursive(
         cls, fn: typing.Callable[[FunctionOne[T, U], T], U]
@@ -87,37 +80,31 @@ class FunctionOne(Expression, typing.Generic[T, U]):
 
         return cls.create(fn.__name__, inner)
 
-    @expression
     def __call__(self, arg: T) -> U:
         ...
 
-    @expression
     @classmethod
     def create(cls, name: str, val: Abstraction[T, U]) -> FunctionOne[T, U]:
         ...
 
-    @expression  # type: ignore
     @property
     def abstraction(self) -> Abstraction[T, U]:
         ...
 
-    @expression  # type: ignore
     @property
     def name(self) -> str:
         ...
 
-    @expression  # type: ignore
     @property
     def unfix(self) -> Abstraction[FunctionOne[T, U], FunctionOne[T, U]]:
         ...
 
 
-class FunctionTwo(Expression, typing.Generic[T, U, V]):
+class FunctionTwo(Expression, typing.Generic[T, U, V], wrap_methods=True):
     """
     Function with two args.
     """
 
-    @expression
     @classmethod
     def from_fn(cls, fn: typing.Callable[[T, U], V]) -> FunctionTwo[T, U, V]:
         def inner(arg1: T) -> Abstraction[U, V]:
@@ -128,7 +115,6 @@ class FunctionTwo(Expression, typing.Generic[T, U, V]):
 
         return cls.create(fn.__name__, Abstraction.from_fn(inner))
 
-    @expression
     @classmethod
     def from_fn_recursive(
         cls, fn: typing.Callable[[FunctionTwo[T, U, V], T, U], V]
@@ -152,39 +138,33 @@ class FunctionTwo(Expression, typing.Generic[T, U, V]):
 
         return cls.create(fn.__name__, inner)
 
-    @expression
     def __call__(self, arg1: T, arg2: U) -> V:
         ...
 
-    @expression
     @classmethod
     def create(
         cls, name: str, val: Abstraction[T, Abstraction[U, V]]
     ) -> FunctionTwo[T, U, V]:
         ...
 
-    @expression  # type: ignore
     @property
     def abstraction(self) -> Abstraction[T, Abstraction[U, V]]:
         ...
 
-    @expression  # type: ignore
     @property
     def name(self) -> str:
         ...
 
-    @expression  # type: ignore
     @property
     def unfix(self) -> Abstraction[FunctionTwo[T, U, V], FunctionTwo[T, U, V]]:
         ...
 
 
-class FunctionThree(Expression, typing.Generic[T, U, V, X]):
+class FunctionThree(Expression, typing.Generic[T, U, V, X], wrap_methods=True):
     """
     Function with three args.
     """
 
-    @expression
     @classmethod
     def from_fn(cls, fn: typing.Callable[[T, U, V], X]) -> FunctionThree[T, U, V, X]:
         @Abstraction.from_fn
@@ -201,7 +181,6 @@ class FunctionThree(Expression, typing.Generic[T, U, V, X]):
 
         return cls.create(fn.__name__, inner)
 
-    @expression
     @classmethod
     def from_fn_recursive(
         cls, fn: typing.Callable[[FunctionThree[T, U, V, X], T, U, V], X]
@@ -229,28 +208,23 @@ class FunctionThree(Expression, typing.Generic[T, U, V, X]):
 
         return cls.create(fn.__name__, inner)
 
-    @expression
     def __call__(self, arg1: T, arg2: U, arg3: V) -> X:
         ...
 
-    @expression
     @classmethod
     def create(
         cls, name: str, val: Abstraction[T, Abstraction[U, Abstraction[V, X]]]
     ) -> FunctionThree[T, U, V, X]:
         ...
 
-    @expression  # type: ignore
     @property
     def abstraction(self) -> Abstraction[T, Abstraction[U, Abstraction[V, X]]]:
         ...
 
-    @expression  # type: ignore
     @property
     def name(self) -> str:
         ...
 
-    @expression  # type: ignore
     @property
     def unfix(
         self,

--- a/metadsl_core/integer.py
+++ b/metadsl_core/integer.py
@@ -16,72 +16,56 @@ __all__ = ["Integer"]
 T = typing.TypeVar("T")
 
 
-class Integer(Expression):
-    @expression
+class Integer(Expression, wrap_methods=True):
     @classmethod
     def from_int(cls, i: int) -> Integer:
         ...
 
-    @expression
     def __add__(self, other: Integer) -> Integer:
         ...
 
-    @expression
     def __sub__(self, other: Integer) -> Integer:
         ...
 
-    @expression
     def __mul__(self, other: Integer) -> Integer:
         ...
 
-    @expression
     def __floordiv__(self, other: Integer) -> Integer:
         ...
 
-    @expression
     def __mod__(self, other: Integer) -> Integer:
         ...
 
-    @expression
     def eq(self, other: Integer) -> Boolean:
         ...
 
-    @expression
     def __lt__(self, other: Integer) -> Boolean:
         ...
 
-    @expression
     def __le__(self, other: Integer) -> Boolean:
         ...
 
-    @expression
     def __gt__(self, other: Integer) -> Boolean:
         ...
 
-    @expression
     def __ge__(self, other: Integer) -> Boolean:
         ...
 
-    @expression
     def fold(self, initial: T, fn: Abstraction[Integer, Abstraction[T, T]]) -> T:
         ...
 
-    @expression
     @classmethod
     def zero(cls) -> Integer:
         return Integer.from_int(0)
 
-    @expression
     @classmethod
     def one(cls) -> Integer:
         return cls.zero().inc
 
-    @expression  # type: ignore
     @property
     def inc(self) -> Integer:
         return self + Integer.from_int(1)
 
-    @expression
     @classmethod
     def infinity(cls) -> Integer:
         ...

--- a/metadsl_core/maybe.py
+++ b/metadsl_core/maybe.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
+
 import typing
 
 from metadsl import *
 from metadsl_rewrite import *
 
 from .abstraction import *
-from .strategies import *
 from .pair import *
+from .strategies import *
 
 __all__ = ["Maybe", "collapse_maybe"]
 T = typing.TypeVar("T")
@@ -14,37 +15,31 @@ U = typing.TypeVar("U")
 V = typing.TypeVar("V")
 
 
-class Maybe(Expression, typing.Generic[T]):
+class Maybe(Expression, typing.Generic[T], wrap_methods=True):
     """
     An optional value.
     """
 
-    @expression
     @classmethod
     def nothing(cls) -> Maybe[T]:
         ...
 
-    @expression
     @classmethod
     def just(cls, value: T) -> Maybe[T]:
         ...
 
-    @expression
     def match(self, nothing: U, just: Abstraction[T, U]) -> U:
         ...
 
-    @expression
     def default(self, value: T) -> T:
         return self.match(value, Abstraction[T, T].from_fn(lambda i: i))
 
-    @expression
     def __or__(self, other: Maybe[T]) -> Maybe[T]:
         """
         Like the <|> function https://en.wikibooks.org/wiki/Haskell/Alternative_and_MonadPlus
         """
         ...
 
-    @expression
     def __and__(self, other: Maybe[U]) -> Maybe[Pair[T, U]]:
         """
         >>> execute(Maybe[int].nothing() & Maybe.just("")) == Maybe[Pair[int, str]].nothing()
@@ -56,14 +51,12 @@ class Maybe(Expression, typing.Generic[T]):
         """
         ...
 
-    @expression
     def map(self, just: Abstraction[T, U]) -> Maybe[U]:
         return self.match(
             Maybe[U].nothing(),
             Abstraction[U, Maybe[U]].from_fn(lambda v: Maybe.just(v)) + just,  # type: ignore
         )
 
-    @expression
     def flat_map(self, just: Abstraction[T, Maybe[U]]) -> Maybe[U]:
         return collapse_maybe(self.map(just))
 

--- a/metadsl_core/vec.py
+++ b/metadsl_core/vec.py
@@ -5,11 +5,11 @@ import typing
 from metadsl import *
 from metadsl_rewrite import *
 
+from .abstraction import *
 from .boolean import *
+from .conversion import *
 from .integer import *
 from .maybe import *
-from .conversion import *
-from .abstraction import *
 from .pair import *
 from .strategies import *
 
@@ -88,16 +88,14 @@ class Selection(Expression):
 register_ds(default_rule(Selection.create_slice_optional))
 
 
-class Vec(Expression, typing.Generic[T]):
+class Vec(Expression, typing.Generic[T], wrap_methods=True):
     """
     A tuple of homogonous types.
     """
 
-    @expression
     def __getitem__(self, index: Integer) -> T:
         ...
 
-    @expression
     def select(self, selection: Selection) -> Vec[T]:
         ...
 
@@ -107,20 +105,16 @@ class Vec(Expression, typing.Generic[T]):
     # @expression
     # def full_single_index
 
-    @expression
     @classmethod
     def create(cls, *items: T) -> Vec[T]:
         ...
 
-    @expression
     def map(self, fn: Abstraction[T, U]) -> Vec[U]:
         ...
 
-    @expression
     def append(self, x: T) -> Vec[T]:
         ...
 
-    @expression
     def fold(self, initial: U, fn: Abstraction[U, Abstraction[T, U]]) -> U:
         """
         Like this:
@@ -132,47 +126,37 @@ class Vec(Expression, typing.Generic[T]):
                 return ret
         """
 
-    @expression
     def __add__(self, other: Vec[T]) -> Vec[T]:
         ...
 
-    @expression  # type: ignore
     @property
     def length(self) -> Integer:
         ...
 
-    @expression
     def take(self, i: Integer) -> Vec[T]:
         ...
 
-    @expression
     def drop(self, i: Integer) -> Vec[T]:
         ...
 
-    @expression
     @classmethod
     def create_fn(cls, length: Integer, fn: Abstraction[Integer, T]) -> Vec[T]:
         ...
 
-    @expression
     @classmethod
     def lift_maybe(cls, vec: Vec[Maybe[T]]) -> Maybe[Vec[T]]:
         ...
 
-    @expression
     def set(self, i: Integer, value: T) -> Vec[T]:
         ...
 
-    @expression
     def set_selection(self, s: Selection, values: Vec[T]) -> Vec[T]:
         ...
 
-    @expression  # type: ignore
     @property
     def empty(self) -> Boolean:
         return self.length.eq(Integer.zero())
 
-    @expression  # type: ignore
     @property
     def first(self) -> Maybe[T]:
         return self.empty.if_(Maybe[T].nothing(), Maybe.just(self[Integer.zero()]))


### PR DESCRIPTION
This PR adds support for automatically wrapping all methods as expressions, to make it less verbose to write classes.

It completes part of the RFC to make it easier to write datatypes.