### PR TITLE
Add datatype rules

### DIFF
--- a/metadsl/normalized.py
+++ b/metadsl/normalized.py
@@ -339,7 +339,11 @@ def graph_str(graph: Graph) -> str:
                 value_str = f"{expr._function_str}({', '.join(args)})"
             no_temp_var = False
         else:
-            value_str = repr(expr)
+            # Special case object repr so that its formattable
+            if type(expr) == object:
+                value_str = f"object({hex(id(expr))})"
+            else:
+                value_str = repr(expr)
             # Never save a primitive value as a temp variable
             no_temp_var = True
 

--- a/metadsl_rewrite/rules_test.py
+++ b/metadsl_rewrite/rules_test.py
@@ -530,3 +530,42 @@ class TestDefaultRule:
                 ...
 
         globals()["C"] = C
+
+
+class _Datatype(Expression):
+    @expression
+    @classmethod
+    def create(cls, i: int, b: str) -> _Datatype:
+        pass
+
+    @expression  # type: ignore
+    @property
+    def i(self) -> int:
+        pass
+
+    @expression  # type: ignore
+    @property
+    def b(self) -> str:
+        pass
+
+    @expression
+    def set_i(self, i: int) -> _Datatype:
+        pass
+
+    @expression
+    def set_b(self, b: str) -> _Datatype:
+        pass
+
+
+datatypes_rule_ = datatype_rule(_Datatype)
+
+class TestDatatypeRule:
+    def test_getters(self):
+        expr = _Datatype.create(1, "a")
+        assert execute(expr.i, datatypes_rule_) == 1
+        assert execute(expr.b, datatypes_rule_) == "a"
+
+    def test_setters(self):
+        expr = _Datatype.create(1, "a")
+        assert execute(expr.set_i(2), datatypes_rule_) == _Datatype.create(2, "a")
+        assert execute(expr.set_b("b"), datatypes_rule_) == _Datatype.create(1, "b")


### PR DESCRIPTION
This completes the second part of RFC 1 by adding support for automatically creating rules for datatypes setters and getters.