### PR TITLE
Fixups

### DIFF
--- a/metadsl/expressions.py
+++ b/metadsl/expressions.py
@@ -104,7 +104,7 @@ class Expression(GenericCheck):
         )
     
     @classmethod
-    def __init_subclass__(cls, /, wrap_methods=False, **kwargs) -> None:
+    def __init_subclass__(cls, wrap_methods=False, **kwargs) -> None:
         """
         If `wrap_methods` is passed in a subclass, wrap all methods in an `expresion` decorator.
         """

--- a/metadsl/expressions.py
+++ b/metadsl/expressions.py
@@ -52,6 +52,9 @@ class Expression(GenericCheck):
 
     @property
     def _function_str(self):
+        # If this is a bound function, use it's repr so that get the generic params and the method
+        if isinstance(self.function, BoundInfer):
+            return repr(self.function)
         return getattr(self.function, "__qualname__", str(self.function))
 
     @property

--- a/metadsl/normalized.py
+++ b/metadsl/normalized.py
@@ -371,7 +371,7 @@ def graph_str(graph: Graph) -> str:
             tp_name_to_index[tp_name] += 1
             hash_to_str[hash_] = var_name
             lines.append(f"{var_name} = {value_str}")
-    return black.format_str("\n".join(lines), mode=black.FileMode(line_length=140))
+    return black.format_str("\n".join(lines), mode=black.FileMode(line_length=140)).strip()
 
 
 # Override the repr for an expression to display it as a string

--- a/metadsl/normalized.py
+++ b/metadsl/normalized.py
@@ -3,6 +3,7 @@ Normalized expressions, for deduping and single replacements.
 """
 from __future__ import annotations
 
+import ast
 import collections
 import dataclasses
 import functools
@@ -11,7 +12,6 @@ import typing
 
 import black
 import igraph
-import IPython.core.display
 import typing_inspect
 
 from .expressions import *
@@ -344,6 +344,11 @@ def graph_str(graph: Graph) -> str:
                 value_str = f"object({hex(id(expr))})"
             else:
                 value_str = repr(expr)
+                # if we cannot parse the repr as a python expression, turn it into a string instead
+                try:
+                    ast.parse(value_str, mode="eval")
+                except SyntaxError:
+                    value_str = repr(value_str)
             # Never save a primitive value as a temp variable
             no_temp_var = True
 

--- a/metadsl/normalized_test.py
+++ b/metadsl/normalized_test.py
@@ -137,4 +137,4 @@ class E(Expression):
     ],
 )
 def test_graph_str(expr, s):
-    assert graph_str(Graph(expr)) == s + "\n"
+    assert graph_str(Graph(expr)) == s

--- a/metadsl/typing_tools.py
+++ b/metadsl/typing_tools.py
@@ -822,7 +822,7 @@ def type_repr(tp: type) -> str:
     """
     if isinstance(tp, typing.TypeVar):
         return repr(tp)
-    tp_name = tp.__qualname__
+    tp_name = tp.__name__
     args = getattr(tp, "__args__", [])
     if args:
         return f"{tp_name}[{', '.join(map(type_repr, args))}]"

--- a/metadsl/typing_tools.py
+++ b/metadsl/typing_tools.py
@@ -811,10 +811,22 @@ class BoundInfer(typing.Generic[T, U]):
         return res
 
     def __repr__(self):
-        # Generic types are already formatted nicely
-        owner_str = self.owner.__name__
-        return f"{owner_str}.{self.fn.__name__}"
+        return f"{type_repr(self.owner)}.{self.fn.__name__}"
 
+    
+def type_repr(tp: type) -> str:
+    """
+    Returns the repr for the type, preserving any generic params.
+
+    Unlike the builtin generic type repr, it does not include the module. 
+    """
+    if isinstance(tp, typing.TypeVar):
+        return repr(tp)
+    tp_name = tp.__qualname__
+    args = getattr(tp, "__args__", [])
+    if args:
+        return f"{tp_name}[{', '.join(map(type_repr, args))}]"
+    return tp_name
 
 def infer(
     fn: typing.Callable[..., T], wrapper: WrapperType[T, U]

--- a/metadsl/typing_tools.py
+++ b/metadsl/typing_tools.py
@@ -489,6 +489,10 @@ def match_types(hint: typing.Type, t: typing.Type) -> TypeVarMapping:
                 return {}
         return match_types(typing_inspect.get_args(hint)[0], t_inner)
 
+    # Special case optional types to avoid... For Maybe[T].from_optional
+    if typing_inspect.is_optional_type(hint):
+        return {}
+
     if typing_inspect.is_union_type(hint):
         # If this is a union, iterate through and use the first that is a subclass
         for inner_type in typing_inspect.get_args(hint):

--- a/metadsl/typing_tools.py
+++ b/metadsl/typing_tools.py
@@ -820,9 +820,9 @@ def type_repr(tp: type) -> str:
 
     Unlike the builtin generic type repr, it does not include the module. 
     """
-    if isinstance(tp, typing.TypeVar):
+    if isinstance(tp, (typing.TypeVar, typing._SpecialForm)):
         return repr(tp)
-    tp_name = tp.__name__
+    tp_name = tp.__qualname__
     args = getattr(tp, "__args__", [])
     if args:
         return f"{tp_name}[{', '.join(map(type_repr, args))}]"

--- a/metadsl_core/maybe.py
+++ b/metadsl_core/maybe.py
@@ -60,6 +60,37 @@ class Maybe(Expression, typing.Generic[T], wrap_methods=True):
     def flat_map(self, just: Abstraction[T, Maybe[U]]) -> Maybe[U]:
         return collapse_maybe(self.map(just))
 
+    def expect(self) -> T:
+        """
+        If the maybe is something, it returns that value, if it is nothing,
+        then it will never resolve.
+
+        >>> execute(Maybe.just(10).expect())
+        10
+        >>> execute(Maybe.nothing().expect())
+        Maybe.nothing().expect()
+        """
+        ...
+    
+    @classmethod
+    def from_optional(cls, value: typing.Optional[T]) -> Maybe[T]:
+        """
+        >>> execute(Maybe.from_optional(None))
+        Maybe.nothing()
+        >>> execute(Maybe.from_optional(10))
+        Maybe.just(10)
+        """
+        ...
+        if value is None:
+            return cls.nothing()
+        else:
+            return cls.just(value)
+
+@register_core
+@rule
+def expect_maybe(x: T) -> R[T]:
+    return Maybe.just(x).expect(), x
+
 
 @expression
 def collapse_maybe(x: Maybe[Maybe[T]]) -> Maybe[T]:
@@ -71,6 +102,7 @@ def collapse_maybe(x: Maybe[Maybe[T]]) -> Maybe[T]:
 register_core(default_rule(Maybe[T].map))
 register_core(default_rule(Maybe[T].default))
 register_core(default_rule(Maybe[T].flat_map))
+register_core(default_rule(Maybe[T].from_optional))
 register_core(default_rule(collapse_maybe))
 
 

--- a/metadsl_core/maybe.py
+++ b/metadsl_core/maybe.py
@@ -75,10 +75,10 @@ class Maybe(Expression, typing.Generic[T], wrap_methods=True):
     @classmethod
     def from_optional(cls, value: typing.Optional[T]) -> Maybe[T]:
         """
-        >>> execute(Maybe.from_optional(None))
-        Maybe.nothing()
-        >>> execute(Maybe.from_optional(10))
-        Maybe.just(10)
+        >>> execute(Maybe[int].from_optional(None))
+        Maybe[int].nothing()
+        >>> execute(Maybe[int].from_optional(10))
+        Maybe[int].just(10)
         """
         ...
         if value is None:

--- a/metadsl_core/vec.py
+++ b/metadsl_core/vec.py
@@ -139,6 +139,12 @@ class Vec(Expression, typing.Generic[T], wrap_methods=True):
     def drop(self, i: Integer) -> Vec[T]:
         ...
 
+    def pop(self) -> Pair[Vec[T], T]:
+        """
+        Pops the first element off the vector and returns it and the rest of the vector.
+        """
+        ...
+
     @classmethod
     def create_fn(cls, length: Integer, fn: Abstraction[Integer, T]) -> Vec[T]:
         ...
@@ -192,10 +198,13 @@ def create_fn_rules(
     yield v.length, l
     yield v.take(n), Vec.create_fn(l - n, fn)
     yield v.drop(n), Vec.create_fn(
-        l - n, Abstraction[Integer, T].from_fn(lambda i: fn(i + n)),
+        l - n,
+        Abstraction[Integer, T].from_fn(lambda i: fn(i + n)),
     )
+    yield v.pop(), Pair.create(Vec.create_fn(l - one, fn), v[l])
     yield v.select(s), Vec.create_fn(
-        s.length(l), Abstraction[Integer, T].from_fn(lambda i: v[s.new_to_old(i)]),
+        s.length(l),
+        Abstraction[Integer, T].from_fn(lambda i: v[s.new_to_old(i)]),
     )
     yield v.set(n, x), Vec.create_fn(
         l, Abstraction[Integer, T].from_fn(lambda i: i.eq(n).if_(x, fn(i)))
@@ -247,6 +256,13 @@ def take_drop_rule(xs: typing.Sequence[T], i: int) -> R[Vec[T]]:
         lambda: Vec[T].create(*xs[i:]),
     )
 
+@register_ds
+@rule
+def pop_rule(xs: typing.Sequence[T], x: T) -> R[Pair[Vec[T], T]]:
+    yield (
+        Vec[T].create(*xs, x).pop(),
+        lambda: Pair.create(Vec[T].create(*xs), x),
+    )
 
 @register_ds  # type: ignore
 @rule

--- a/metadsl_core/vec_test.py
+++ b/metadsl_core/vec_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from metadsl import *
 from metadsl_rewrite import *
 
@@ -73,4 +74,4 @@ class TestVec:
         )
 
     def test_pop(self):
-        assert execute(Vec.create(10, 11).pop()) == Pair.create(Vec.create(10), 11)
+        assert execute(Vec.create(10, 11).pop()) == Pair.create(Vec[int].create(10), 11)

--- a/metadsl_core/vec_test.py
+++ b/metadsl_core/vec_test.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
-import pytest
 
+import pytest
 from metadsl import *
 from metadsl_rewrite import *
 
+from .abstraction import *
 from .conversion import *
 from .either import *
-from .abstraction import *
-from .strategies import *
-from .maybe import *
-from .vec import *
 from .integer import *
+from .maybe import *
+from .pair import *
+from .strategies import *
+from .vec import *
 
 
 class Int(Expression):
@@ -70,3 +71,6 @@ class TestVec:
         assert (
             execute(Converter[Vec[Int]].convert(("hi",))) == Maybe[Vec[Int]].nothing()
         )
+
+    def test_pop(self):
+        assert execute(Vec.create(10, 11).pop()) == Pair.create(Vec.create(10), 11)

--- a/metadsl_rewrite/rules.py
+++ b/metadsl_rewrite/rules.py
@@ -20,6 +20,7 @@ import types
 import typing
 
 import typing_inspect
+
 from metadsl import *
 from metadsl.typing_tools import *
 
@@ -147,7 +148,7 @@ def datatype_rule(cls: type[Expression]) -> Strategy:
     match_fn.__qualname__ = cls.__qualname__
 
     # Set __wrapped__ so that get_type_hints finds looks at the globals for this function
-    match_fn.__wrapped__ = create_fn.fn
+    match_fn.__wrapped__ = create_fn.fn # type: ignore
     return Rule(match_fn)
 
 

--- a/metadsl_rewrite/rules.py
+++ b/metadsl_rewrite/rules.py
@@ -144,6 +144,9 @@ def datatype_rule(cls: type[Expression]) -> Strategy:
 
     match_fn.__module__ = cls.__module__
     match_fn.__qualname__ = cls.__qualname__
+
+    # Set __wrapped__ so that get_type_hints finds looks at the globals for this function
+    match_fn.__wrapped__ = create_fn.fn
     return Rule(match_fn)
 
 

--- a/metadsl_rewrite/rules.py
+++ b/metadsl_rewrite/rules.py
@@ -95,8 +95,9 @@ def datatype_rule(cls: type[Expression]) -> Strategy:
         getter = getattr(cls, k)
         if not isinstance(getter, BoundInfer):
             raise ValueError(f"{k} method of {cls} must be an expression")
-        if v != getter.fn.__annotations__['return']:
-            raise ValueError(f"Type of {cls}.{k} does not match type of {cls}.create({k})")
+        return_tp = getter.fn.__annotations__['return']
+        if v != return_tp:
+            raise ValueError(f"Type of accessor {cls.__name__}.{k} -> {return_tp} does not match type of creator {cls.__name__}.create({k}: {v})")
         
         setter_name = f"set_{k}"
         if not hasattr(cls, setter_name):

--- a/metadsl_rewrite/rules_test.py
+++ b/metadsl_rewrite/rules_test.py
@@ -536,12 +536,12 @@ class _Datatype(Expression):
     @expression
     @classmethod
     def create(cls, i: int, b: str) -> _Datatype:
-        pass
+        ...
 
     @expression  # type: ignore
     @property
     def i(self) -> int:
-        pass
+        ...
 
     @expression  # type: ignore
     @property

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.7
+python_version = 3.8
 ignore_missing_imports = True
 warn_redundant_casts = True
 check_untyped_defs = True


### PR DESCRIPTION
This PR includes a number of fixups extracted from #150. 

* Fixing printing of literal expressions whose strings are not AST parseable
* Adding two more methods on `Maybe`, `expect` and `from_optional`
* Add a `pop` method on vecs
* Support datatypes that only allow some fields to be set (followup to #160)
* Fix globals on datatypes. (followup to #160)