### PR TITLE
Switch datatypes to use one update method

### DIFF
--- a/metadsl/typing_tools.py
+++ b/metadsl/typing_tools.py
@@ -505,7 +505,9 @@ def match_types(hint: typing.Type, t: typing.Type) -> TypeVarMapping:
         )
 
     logger.debug("checking if type subclass hint hint=%s type=%s", hint, t)
-    if not issubclass(t, hint):
+    # Special case ellipsis to allow it to be used as a wildcard
+    # to support using ... as default argument
+    if not issubclass(t, hint) and not isinstance(..., t):
         logger.debug("not subclass")
         raise TypeError(f"Cannot match concrete type {t} with hint {hint}")
     return merge_typevars(

--- a/metadsl_python/code_data.py
+++ b/metadsl_python/code_data.py
@@ -75,6 +75,19 @@ class MCodeData(Expression, wrap_methods=True):
     ) -> MCodeData:
         ...
 
+    def update(
+        self,
+        blocks: MBlocks = ...,
+        filename: str = ...,
+        first_line_number: int = ...,
+        name: str = ...,
+        stacksize: int = ...,
+        type: MTypeOfCode = ...,
+        freevars: Vec[str] = ...,
+        future_annotations: bool = ...,
+    ) -> MCodeData:
+        ...
+
     @property
     def blocks(self) -> MBlocks:
         ...
@@ -105,30 +118,6 @@ class MCodeData(Expression, wrap_methods=True):
 
     @property
     def future_annotations(self) -> bool:
-        ...
-
-    def set_blocks(self, blocks: MBlocks) -> MCodeData:
-        ...
-
-    def set_filename(self, filename: str) -> MCodeData:
-        ...
-
-    def set_first_line_number(self, first_line_number: int) -> MCodeData:
-        ...
-
-    def set_name(self, name: str) -> MCodeData:
-        ...
-
-    def set_stacksize(self, stacksize: int) -> MCodeData:
-        ...
-
-    def set_type(self, type: MTypeOfCode) -> MCodeData:
-        ...
-
-    def set_freevars(self, freevars: Vec[str]) -> MCodeData:
-        ...
-
-    def set_future_annotations(self, future_annotations: bool) -> MCodeData:
         ...
 
     @classmethod

--- a/metadsl_rewrite/rules_test.py
+++ b/metadsl_rewrite/rules_test.py
@@ -546,15 +546,11 @@ class _Datatype(Expression):
     @expression  # type: ignore
     @property
     def b(self) -> str:
-        pass
+        ...
 
     @expression
-    def set_i(self, i: int) -> _Datatype:
-        pass
-
-    @expression
-    def set_b(self, b: str) -> _Datatype:
-        pass
+    def update(self, i: int = ..., b: str = ...) -> _Datatype:
+        ...
 
 
 datatypes_rule_ = datatype_rule(_Datatype)
@@ -566,7 +562,11 @@ class TestDatatypeRule:
         assert execute(expr.i, datatypes_rule_) == 1
         assert execute(expr.b, datatypes_rule_) == "a"
 
-    def test_setters(self):
+    def test_update(self):
         expr = _Datatype.create(1, "a")
-        assert execute(expr.set_i(2), datatypes_rule_) == _Datatype.create(2, "a")
-        assert execute(expr.set_b("b"), datatypes_rule_) == _Datatype.create(1, "b")
+        assert execute(expr.update(), datatypes_rule_) == _Datatype.create(1, "a")
+        assert execute(expr.update(i=2), datatypes_rule_) == _Datatype.create(2, "a")
+        assert execute(expr.update(b="b"), datatypes_rule_) == _Datatype.create(1, "b")
+        assert execute(expr.update(i=2, b="b"), datatypes_rule_) == _Datatype.create(
+            2, "b"
+        )


### PR DESCRIPTION
Instead of having multiple set methods, one per field, this change datatypes to have one update method, where you can pass any number of fields. 

This makes it easier to update multiple fields at once and also reduces the number of methods needed