### PR TITLE
change python-igraph to igraph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ home-page = "https://github.com/Quansight-Labs/metadsl"
 requires = [
     "typing_extensions",
     "typing_inspect",
-    "python-igraph>=0.8.0"
+    "igraph>=0.8.0"
 ]
 requires-python = ">=3.8,<=3.10"
 classifiers = [


### PR DESCRIPTION
Please see https://github.com/igraph/python-igraph/issues/699 for the explanation.

Note that 0.9.8 is the first version available under the `igraph` name. The `python-igraph` name is deprecated and updates will soon cease under this name.